### PR TITLE
Print entire stack trace on debug logs instead of current frame

### DIFF
--- a/addons/logger/logger.gd
+++ b/addons/logger/logger.gd
@@ -97,7 +97,8 @@ func logger(message:String,values,log_level=LogLevel.INFO):
 	_write_logs(msg)
 	match log_level:
 		LogLevel.DEBUG:
-			print_debug(msg)
+			print(msg)
+			print_stack()
 		LogLevel.INFO:
 			print(msg)
 		LogLevel.WARN:


### PR DESCRIPTION
Replace the use of `print_debug` with calls to `print()` and `print_stack()` to print the entire stack trace instead of the current frame. Printing the current frame results in printing the frame where `print_debug()` is called when the expected behavior would be to print either the frame where the GodotLogger method was called or to print the entire stack trace.

Closes #2 