### PR TITLE
Fix issues #8 #9 #10 #11, output valid json for all value types

### DIFF
--- a/addons/logger/logger.gd
+++ b/addons/logger/logger.gd
@@ -82,15 +82,16 @@ func logger(message:String,values,log_level=LogLevel.INFO):
 				msg = msg.left(msg.length()-1)+"}"
 		TYPE_PACKED_BYTE_ARRAY:
 			if values == null:
-				return
-			msg += JSON.stringify(JsonData.unmarshal_bytes_to_dict(values))
+				msg += JSON.stringify(null)
+			else:
+				msg += JSON.stringify(JsonData.unmarshal_bytes_to_dict(values))
 		TYPE_OBJECT:
 			if values == null:
-				return
-			
-			msg += JSON.stringify(JsonData.to_dict(values,false))
+				msg += JSON.stringify(null)
+			else:
+				msg += JSON.stringify(JsonData.to_dict(values,false))
 		TYPE_NIL:
-			return
+			msg += JSON.stringify(null)
 		_:
 			msg += JSON.stringify(values)
 	if OS.get_main_thread_id() != OS.get_thread_caller_id() and log_level == LogLevel.DEBUG:

--- a/addons/logger/logger.gd
+++ b/addons/logger/logger.gd
@@ -65,10 +65,10 @@ func logger(message:String,values,log_level=LogLevel.INFO):
 	match typeof(values):
 		TYPE_ARRAY:
 			if values.size() > 0:
-				msg += "{"
+				msg += "["
 				for k in values:
-					msg += "{k}".format({"k":k})
-				msg = msg.left(msg.length()-1)+"}"
+					msg += "{k},".format({"k":JSON.stringify(k)})
+				msg = msg.left(msg.length()-1)+"]"
 		TYPE_DICTIONARY:
 			for k in _default_args:
 				values[k] = _default_args[k]
@@ -76,9 +76,9 @@ func logger(message:String,values,log_level=LogLevel.INFO):
 				msg += "{"
 				for k in values:
 					if typeof(values[k]) == TYPE_OBJECT && values[k] != null:
-						msg += '"{k}":"{v}",'.format({"k":k,"v":JSON.stringify(JsonData.to_dict(values[k],false))})
+						msg += '{k}:{v},'.format({"k":JSON.stringify(k),"v":JSON.stringify(JsonData.to_dict(values[k],false))})
 					else:
-						msg += '"{k}":"{v}",'.format({"k":k,"v":values[k]})
+						msg += '{k}:{v},'.format({"k":JSON.stringify(k),"v":JSON.stringify(values[k])})
 				msg = msg.left(msg.length()-1)+"}"
 		TYPE_PACKED_BYTE_ARRAY:
 			if values == null:

--- a/addons/logger/logger.gd
+++ b/addons/logger/logger.gd
@@ -76,9 +76,9 @@ func logger(message:String,values,log_level=LogLevel.INFO):
 				msg += "{"
 				for k in values:
 					if typeof(values[k]) == TYPE_OBJECT && values[k] != null:
-						msg += '{k}:{v},'.format({"k":JSON.stringify(k),"v":JSON.stringify(JsonData.to_dict(values[k],false))})
+						msg += '"{k}":{v},'.format({"k":k,"v":JSON.stringify(JsonData.to_dict(values[k],false))})
 					else:
-						msg += '{k}:{v},'.format({"k":JSON.stringify(k),"v":JSON.stringify(values[k])})
+						msg += '"{k}":{v},'.format({"k":k,"v":JSON.stringify(values[k])})
 				msg = msg.left(msg.length()-1)+"}"
 		TYPE_PACKED_BYTE_ARRAY:
 			if values == null:

--- a/addons/logger/logger.gd
+++ b/addons/logger/logger.gd
@@ -92,7 +92,7 @@ func logger(message:String,values,log_level=LogLevel.INFO):
 		TYPE_NIL:
 			return
 		_:
-			msg += values
+			msg += JSON.stringify(values)
 	if OS.get_main_thread_id() != OS.get_thread_caller_id() and log_level == LogLevel.DEBUG:
 		print("[%d]Cannot retrieve debug info outside the main thread:\n\t%s" % [OS.get_thread_caller_id(),msg])
 		return


### PR DESCRIPTION
Fixes #8 #9 #10 and #11 .

Most of the types do not output valid JSON to the log. This PR makes valid json for array, dictionary, integer, float, bool, and null types.

With this pull request, for the following script: 
```
extends Control


class InventoryItem extends Resource:
	@export var itemtype: int = 0
	@export var metadata: Dictionary = {}
	@export var quantity: int = 1


func _ready():
	GodotLogger.info("this is an array", ["foobar", 5, 3.14, false, null])
	var d = {
		"foobar": "bazqux",
		5: 25,
		3.14: 12e3,
		true: false,
		null: null,
		"an object": InventoryItem.new(),
		InventoryItem.new(): "don't use objects as keys"
	}
	GodotLogger.info("this is an array", d)
	GodotLogger.info("this is an object", InventoryItem.new())
	GodotLogger.info("this is an integer", 7)
	GodotLogger.info("this is a float", 3.14)
	GodotLogger.info("this is a bool", true)
	GodotLogger.info("this is a null", null)
```

the following is now printed:
```
INFO [23/9/2023 16:48:34] setting log level {"level":"debug"}
INFO [23/9/2023 16:48:34] this is an array ["foobar",5,3.14,false,null]
INFO [23/9/2023 16:48:34] this is an array {"foobar":"bazqux","5":25,"3.14":12000,"true":false,"<null>":null,"an object":{"itemtype":0,"metadata":{},"quantity":1,"resource_local_to_scene":false,"resource_name":"","resource_path":""},"<Resource#-9223372008870378339>":"don't use objects as keys"}
INFO [23/9/2023 16:48:34] this is an object {"itemtype":0,"metadata":{},"quantity":1,"resource_local_to_scene":false,"resource_name":"","resource_path":""}
INFO [23/9/2023 16:48:34] this is an integer 7
INFO [23/9/2023 16:48:34] this is a float 3.14
INFO [23/9/2023 16:48:34] this is a bool true
INFO [23/9/2023 16:48:34] this is a null null
```

I passed the json outputs through https://jsonlint.com/ to validate them.