### PR TITLE
Modify .gitattributes to default Godot Asset Lib install to only "addons" folder.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
-# Normalize EOL for all files that Git considers text files.
+# Normalize line endings for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
Hi guys, thanks for the plugin!

Quick proposal:

The installation via the Godot Asset Lib is really convenient, but right now the .gitattributes file doesn't follow [the suggested format](https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html). Right now, the user should never need to install anything but the /addons/ folder contents.

![image](https://github.com/DawnGroveStudios/GodotLogger/assets/5817861/cc697473-bc06-4460-8168-8614ab38d726)

Right now, I have to install de-selecitng all other files/folders to not have them download to / replace things in my project's root.

Simple change. Could I just ask that you build a new release once merged (if you choose to do so) so I can share the plugin with my team?

thanks!